### PR TITLE
Reopen closed window on macOS

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -37,8 +37,14 @@ app.on('ready', () => {
 
     mainWindow.loadURL(`file://${__dirname}/../../static/index.html`);
 
-    mainWindow.on('closed', () => {
-      mainWindow = null;
+    mainWindow.on('close', (event) => {
+      if(process.platform === 'darwin' && !app.quitting) {
+        event.preventDefault();
+        mainWindow.hide();
+      }
+      else {
+        mainWindow = null;
+      }
     });
 
     mainWindow.webContents.on('did-finish-load', () => {
@@ -72,4 +78,12 @@ app.on('ready', () => {
     // register main app menu
     appMenu.register();
   });
+});
+
+app.on('activate', () => {
+  mainWindow.show();
+});
+
+app.on('before-quit', () => {
+  app.quitting = true;
 });


### PR DESCRIPTION
Based on https://stackoverflow.com/a/45156004

I have only tested this on macOS. I moved the line 'mainWindow = null;' to the 'close' event. I don't think this should break anything...